### PR TITLE
Fix style for command palette

### DIFF
--- a/src/commandpalette/src/CommandPaletteWidget.ts
+++ b/src/commandpalette/src/CommandPaletteWidget.ts
@@ -761,7 +761,9 @@ class CommandPaletteWidget extends Widget {
   }
 
   addResult(result: IResult, id: number) {
-    let resultDiv = this.createElement('div', { className: 'commandpaletteresult', innerText: result.caption || result.name });
+    let resultDiv = this.createElement('div', { className: 'commandpaletteresult' });
+    let titleDiv = this.createElement('div', { className: 'commandpalettetitle', innerText: result.caption || result.name });
+    resultDiv.appendChild(titleDiv);
     if (result.hint !== undefined) {
       let hint = this.createElement('div', { className: 'commandpalettehint', innerText: result.hint });
       resultDiv.appendChild(hint);

--- a/src/commandpalette/src/styles/Compact.css.tid
+++ b/src/commandpalette/src/styles/Compact.css.tid
@@ -1,10 +1,3 @@
-created: 20200603190000307
-modified: 20200623022617588
-tags: $:/tags/CommandPaletteTheme $:/tags/Stylesheet
-title: $:/plugins/linonetwo/commandpalette/Compact.css
-type: text/vnd.tiddlywiki
-
-
 \rules only filteredtranscludeinline transcludeinline macrodef macrocallinline html
 :root {
     --palette-radius: 5px;
@@ -61,16 +54,20 @@ type: text/vnd.tiddlywiki
     flex: 1;
     padding-left: 7px;
 }
+.commandpalettetitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .commandpalettehint {
-    color:  <<colour foreground>>;
     font-size: 13px;
     text-align: right;
     flex-shrink: 0;
     padding-right: 7px;
     opacity: 0.6;
+    font-weight: 800;
 }
 .commandpaletteresultselected>.commandpalettehint {
-    color: <<colour background>>;
     opacity: 1;
 }
 .commandpalettehintmain {
@@ -80,6 +77,7 @@ type: text/vnd.tiddlywiki
     background: <<colour background>>;
     font-size: 15px;
     color: <<colour foreground>>;
+    fill: <<colour foreground>>;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -87,6 +85,7 @@ type: text/vnd.tiddlywiki
     padding-top: 4px;
     padding-bottom: 4px;
     cursor: pointer;
+    width: 100%;
 }
 .commandpaletteresult:not(:last-child) {
     border-bottom: <<colour page-background>> solid 1px;
@@ -97,6 +96,7 @@ type: text/vnd.tiddlywiki
 .commandpaletteresultselected {
     background: <<colour primary>>;
     color: <<colour page-background>>;
+    fill: <<colour page-background>>;
 }
 .cp-scroll{
     max-height: 50vh;

--- a/src/commandpalette/src/styles/Original.css.tid
+++ b/src/commandpalette/src/styles/Original.css.tid
@@ -20,7 +20,7 @@ type: text/vnd.tiddlywiki
     font-size: 21px;
     border-radius: var(--palette-radius);
     box-shadow: rgba(0, 0, 0, 0.15) 0px 0px 14px;
-    border: 4px solid rgba(0, 0, 0, 0);
+    border: 4px solid transparent;
 }
 @media (max-width: 540px) {
   .commandpalette {
@@ -53,16 +53,20 @@ type: text/vnd.tiddlywiki
     width: 100%;
     outline: 0;
 }
+.commandpalettetitle {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .commandpalettehint {
-    color:  <<colour foreground>>;
     font-size: 13px;
     text-align: right;
     flex-shrink: 0;
     padding-right: 7px;
     opacity: 0.6;
+    font-weight: 800;
 }
 .commandpaletteresultselected>.commandpalettehint {
-    color: <<colour background>>;
     opacity: 1;
 }
 .commandpalettehintmain {
@@ -71,6 +75,7 @@ type: text/vnd.tiddlywiki
     background: <<colour background>>;
     font-size: 15px;
     color: <<colour foreground>>;
+    fill: <<colour foreground>>;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -78,6 +83,7 @@ type: text/vnd.tiddlywiki
     padding-top: 4px;
     padding-bottom: 4px;
     cursor: pointer;
+    width: 100%;
 }
 .commandpaletteresult:not(:last-child) {
     border-bottom: <<colour page-background>> solid 1px;
@@ -88,6 +94,7 @@ type: text/vnd.tiddlywiki
 .commandpaletteresultselected {
     background: <<colour primary>>;
     color: <<colour page-background>>;
+    fill: <<colour page-background>>;
 }
 .cp-scroll{
     max-height: 50vh;


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/16955102/138914399-31bd28ef-947c-463a-a323-f1a78b9652a9.png)

Now:

![image](https://user-images.githubusercontent.com/16955102/138914028-52304892-f556-46ab-a32b-b372272c8877.png)
